### PR TITLE
Update PostgreSQL volume path in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
         aliases:
           - ${DB_HOSTNAME-postgresdbbackend}
     volumes:
-      - postgresdb_data:/var/lib/postgresql
+      - postgresdb_data:/var/lib/postgresql/data
     environment:
       - POSTGRES_USER=${DB_USER-admin}
       - POSTGRES_PASSWORD=${DB_PASSWORD-secret}


### PR DESCRIPTION
This PR fixes Postgres data not persisting across container recreation.

The compose file mounted the named volume to /var/lib/postgresql, but the official Postgres image stores its data in PGDATA (/var/lib/postgresql/data). As a result, the database files were written to the container filesystem and were lost when the container was recreated.

**Change**
Mount postgresdb_data to /var/lib/postgresql/data (PGDATA)

**Verification**
On my setup, data was not persisting before this change. After applying this change and recreating the container, it is now persisting as expected.

**Commands I used:**
docker compose down
docker volume rm <project>_postgresdb_data (one-time reset if needed)
docker compose up -d