### PR TITLE
replace env httpd with Infinity refData for carconnectivity_url variable

### DIFF
--- a/config/grafana/provisioning/datasources/carconnectivity-env.yml
+++ b/config/grafana/provisioning/datasources/carconnectivity-env.yml
@@ -9,15 +9,10 @@ datasources:
   - name: CarConnectivity-ENV-json
     orgId: 1
     uid: CarConnectivity-Env-json-provisioned
-    type: marcusolsson-json-datasource
-    access: proxy
-    url: http://localhost:8081/env.json
-    basicAuthUser: grafana
-    secureJsonData:
-      basicAuthPassword: grafanasecretaccesshttpd
-    jsonData:
-      timeout: "1"
-    basicAuth: true
+    type: yesoreyeram-infinity-datasource
     isDefault: false
     editable: false
-    
+    jsonData:
+      refData:
+        - name: env
+          data: '[{"carconnectivity_ui_url":"$CARCONNECTIVITY_UI_URL"}]'

--- a/dashboards/carconnectivity/CarConnectivity/charging_sessions.json
+++ b/dashboards/carconnectivity/CarConnectivity/charging_sessions.json
@@ -806,7 +806,7 @@
       {
         "allowCustomValue": false,
         "datasource": {
-          "type": "marcusolsson-json-datasource",
+          "type": "yesoreyeram-infinity-datasource",
           "uid": "CarConnectivity-Env-json-provisioned"
         },
         "definition": "",
@@ -814,15 +814,22 @@
         "name": "carconnectivity_url",
         "options": [],
         "query": {
-          "cacheDurationSeconds": 86400,
-          "fields": [
-            {
-              "jsonPath": "$.carconnectivity_ui_url"
-            }
-          ],
-          "method": "GET",
-          "queryParams": "",
-          "urlPath": ""
+          "refId": "variable",
+          "queryType": "infinity",
+          "infinityQuery": {
+            "type": "json",
+            "source": "reference",
+            "referenceName": "env",
+            "parser": "backend",
+            "columns": [
+              {
+                "selector": "carconnectivity_ui_url",
+                "text": "carconnectivity_ui_url",
+                "type": "string"
+              }
+            ],
+            "filters": []
+          }
         },
         "refresh": 1,
         "regex": "",

--- a/dashboards/carconnectivity/CarConnectivity/live.json
+++ b/dashboards/carconnectivity/CarConnectivity/live.json
@@ -1377,7 +1377,7 @@
       {
         "allowCustomValue": false,
         "datasource": {
-          "type": "marcusolsson-json-datasource",
+          "type": "yesoreyeram-infinity-datasource",
           "uid": "CarConnectivity-Env-json-provisioned"
         },
         "definition": "",
@@ -1385,15 +1385,22 @@
         "name": "carconnectivity_url",
         "options": [],
         "query": {
-          "cacheDurationSeconds": 86400,
-          "fields": [
-            {
-              "jsonPath": "$.carconnectivity_ui_url"
-            }
-          ],
-          "method": "GET",
-          "queryParams": "",
-          "urlPath": ""
+          "refId": "variable",
+          "queryType": "infinity",
+          "infinityQuery": {
+            "type": "json",
+            "source": "reference",
+            "referenceName": "env",
+            "parser": "backend",
+            "columns": [
+              {
+                "selector": "carconnectivity_ui_url",
+                "text": "carconnectivity_ui_url",
+                "type": "string"
+              }
+            ],
+            "filters": []
+          }
         },
         "refresh": 1,
         "regex": "",

--- a/dashboards/carconnectivity/CarConnectivity/locations.json
+++ b/dashboards/carconnectivity/CarConnectivity/locations.json
@@ -1037,7 +1037,7 @@
           "value": ""
         },
         "datasource": {
-          "type": "marcusolsson-json-datasource",
+          "type": "yesoreyeram-infinity-datasource",
           "uid": "CarConnectivity-Env-json-provisioned"
         },
         "definition": "",
@@ -1045,15 +1045,22 @@
         "name": "carconnectivity_url",
         "options": [],
         "query": {
-          "cacheDurationSeconds": 86400,
-          "fields": [
-            {
-              "jsonPath": "$.carconnectivity_ui_url"
-            }
-          ],
-          "method": "GET",
-          "queryParams": "",
-          "urlPath": ""
+          "refId": "variable",
+          "queryType": "infinity",
+          "infinityQuery": {
+            "type": "json",
+            "source": "reference",
+            "referenceName": "env",
+            "parser": "backend",
+            "columns": [
+              {
+                "selector": "carconnectivity_ui_url",
+                "text": "carconnectivity_ui_url",
+                "type": "string"
+              }
+            ],
+            "filters": []
+          }
         },
         "refresh": 1,
         "regex": "",

--- a/dashboards/carconnectivity/CarConnectivity/overview.json
+++ b/dashboards/carconnectivity/CarConnectivity/overview.json
@@ -3068,7 +3068,7 @@
       {
         "allowCustomValue": false,
         "datasource": {
-          "type": "marcusolsson-json-datasource",
+          "type": "yesoreyeram-infinity-datasource",
           "uid": "CarConnectivity-Env-json-provisioned"
         },
         "definition": "",
@@ -3076,15 +3076,22 @@
         "name": "carconnectivity_url",
         "options": [],
         "query": {
-          "cacheDurationSeconds": 86400,
-          "fields": [
-            {
-              "jsonPath": "$.carconnectivity_ui_url"
-            }
-          ],
-          "method": "GET",
-          "queryParams": "",
-          "urlPath": ""
+          "refId": "variable",
+          "queryType": "infinity",
+          "infinityQuery": {
+            "type": "json",
+            "source": "reference",
+            "referenceName": "env",
+            "parser": "backend",
+            "columns": [
+              {
+                "selector": "carconnectivity_ui_url",
+                "text": "carconnectivity_ui_url",
+                "type": "string"
+              }
+            ],
+            "filters": []
+          }
         },
         "refresh": 1,
         "regex": "",

--- a/dashboards/carconnectivity/CarConnectivity/trips.json
+++ b/dashboards/carconnectivity/CarConnectivity/trips.json
@@ -687,7 +687,7 @@
       {
         "allowCustomValue": false,
         "datasource": {
-          "type": "marcusolsson-json-datasource",
+          "type": "yesoreyeram-infinity-datasource",
           "uid": "CarConnectivity-Env-json-provisioned"
         },
         "definition": "",
@@ -695,15 +695,22 @@
         "name": "carconnectivity_url",
         "options": [],
         "query": {
-          "cacheDurationSeconds": 86400,
-          "fields": [
-            {
-              "jsonPath": "$.carconnectivity_ui_url"
-            }
-          ],
-          "method": "GET",
-          "queryParams": "",
-          "urlPath": ""
+          "refId": "variable",
+          "queryType": "infinity",
+          "infinityQuery": {
+            "type": "json",
+            "source": "reference",
+            "referenceName": "env",
+            "parser": "backend",
+            "columns": [
+              {
+                "selector": "carconnectivity_ui_url",
+                "text": "carconnectivity_ui_url",
+                "type": "string"
+              }
+            ],
+            "filters": []
+          }
         },
         "refresh": 1,
         "regex": "",

--- a/dashboards/carconnectivity/Internal/aggregated_trip_details.json
+++ b/dashboards/carconnectivity/Internal/aggregated_trip_details.json
@@ -1593,7 +1593,7 @@
       {
         "allowCustomValue": false,
         "datasource": {
-          "type": "marcusolsson-json-datasource",
+          "type": "yesoreyeram-infinity-datasource",
           "uid": "CarConnectivity-Env-json-provisioned"
         },
         "definition": "",
@@ -1601,15 +1601,22 @@
         "name": "carconnectivity_url",
         "options": [],
         "query": {
-          "cacheDurationSeconds": 86400,
-          "fields": [
-            {
-              "jsonPath": "$.carconnectivity_ui_url"
-            }
-          ],
-          "method": "GET",
-          "queryParams": "",
-          "urlPath": ""
+          "refId": "variable",
+          "queryType": "infinity",
+          "infinityQuery": {
+            "type": "json",
+            "source": "reference",
+            "referenceName": "env",
+            "parser": "backend",
+            "columns": [
+              {
+                "selector": "carconnectivity_ui_url",
+                "text": "carconnectivity_ui_url",
+                "type": "string"
+              }
+            ],
+            "filters": []
+          }
         },
         "refresh": 1,
         "regex": "",

--- a/dashboards/carconnectivity/Internal/charge_session.json
+++ b/dashboards/carconnectivity/Internal/charge_session.json
@@ -1726,7 +1726,7 @@
       {
         "allowCustomValue": false,
         "datasource": {
-          "type": "marcusolsson-json-datasource",
+          "type": "yesoreyeram-infinity-datasource",
           "uid": "CarConnectivity-Env-json-provisioned"
         },
         "definition": "",
@@ -1734,15 +1734,22 @@
         "name": "carconnectivity_url",
         "options": [],
         "query": {
-          "cacheDurationSeconds": 86400,
-          "fields": [
-            {
-              "jsonPath": "$.carconnectivity_ui_url"
-            }
-          ],
-          "method": "GET",
-          "queryParams": "",
-          "urlPath": ""
+          "refId": "variable",
+          "queryType": "infinity",
+          "infinityQuery": {
+            "type": "json",
+            "source": "reference",
+            "referenceName": "env",
+            "parser": "backend",
+            "columns": [
+              {
+                "selector": "carconnectivity_ui_url",
+                "text": "carconnectivity_ui_url",
+                "type": "string"
+              }
+            ],
+            "filters": []
+          }
         },
         "refresh": 1,
         "regex": "",

--- a/dashboards/carconnectivity/Internal/trip_details.json
+++ b/dashboards/carconnectivity/Internal/trip_details.json
@@ -1135,7 +1135,7 @@
           "value": ""
         },
         "datasource": {
-          "type": "marcusolsson-json-datasource",
+          "type": "yesoreyeram-infinity-datasource",
           "uid": "CarConnectivity-Env-json-provisioned"
         },
         "definition": "",
@@ -1143,15 +1143,22 @@
         "name": "carconnectivity_url",
         "options": [],
         "query": {
-          "cacheDurationSeconds": 86400,
-          "fields": [
-            {
-              "jsonPath": "$.carconnectivity_ui_url"
-            }
-          ],
-          "method": "GET",
-          "queryParams": "",
-          "urlPath": ""
+          "refId": "variable",
+          "queryType": "infinity",
+          "infinityQuery": {
+            "type": "json",
+            "source": "reference",
+            "referenceName": "env",
+            "parser": "backend",
+            "columns": [
+              {
+                "selector": "carconnectivity_ui_url",
+                "text": "carconnectivity_ui_url",
+                "type": "string"
+              }
+            ],
+            "filters": []
+          }
         },
         "refresh": 1,
         "regex": "",


### PR DESCRIPTION
Switch CarConnectivity-ENV-json datasource from
marcusolsson-json-datasource (requiring a local httpd on :8081) to yesoreyeram-infinity-datasource using its refData feature. The URL is stored inline in the provisioning YAML with $CARCONNECTIVITY_UI_URL substitution, requiring no extra process or file.